### PR TITLE
Fixed CMOS Checksum Error & allowed setting default boot entry

### DIFF
--- a/EFI/OC/Config.plist
+++ b/EFI/OC/Config.plist
@@ -1817,7 +1817,7 @@
 			<key>DisableLinkeditJettison</key>
 			<true/>
 			<key>DisableRtcChecksum</key>
-			<false/>
+			<true/>
 			<key>ExtendBTFeatureFlags</key>
 			<false/>
 			<key>ExternalDiskIcons</key>
@@ -1915,7 +1915,7 @@
 			<key>AllowNvramReset</key>
 			<true/>
 			<key>AllowSetDefault</key>
-			<false/>
+			<true/>
 			<key>ApECID</key>
 			<integer>0</integer>
 			<key>AuthRestart</key>


### PR DESCRIPTION
**### 1.  Changed DisableRtcChecksum to TRUE in Config.plist under Kernel -> Quirks.** 
> There was an issue when you shutdown AppleRTC will write to certain areas that are not supported by the hardware properly causing the error "0251- CMOS bad checksum error - Default configuration used". DisablingRtcChecksum fixes this issue

**### 2. Allowed setting default boot entry**

> Changed AllowSetDefault to TRUE in Config.plist under Misc -> Security. This is so that Opencore can remember the last boot option (Windows or macOS or Linux) so that it can auto select it on boot without reverting back to the first boot entry on the list

Signed-off-by: racka98
